### PR TITLE
use length.out rather than by = 1

### DIFF
--- a/R/build_limits_lookup.R
+++ b/R/build_limits_lookup.R
@@ -31,7 +31,7 @@ build_limits_lookup<-function(min_preds, max_preds, min_ratio, max_ratio, Poisso
 
     # general limits + Tau2 limits table
     set.seed(1)
-    number.seq <- c(seq(0.1, 10, 0.1), seq(11.0, max_preds, 1))
+    number.seq <- c(seq(0.1, 10, 0.1), seq(11.0, max_preds, length.out = 1000))
     dfCI <- data.frame(
       number.seq,
       ll95 = multiplier * ((qchisq(0.975, 2 * number.seq, lower.tail = FALSE) / 2) / number.seq),
@@ -42,7 +42,7 @@ build_limits_lookup<-function(min_preds, max_preds, min_ratio, max_ratio, Poisso
   } else if (method == "SHMI") {
     # general limits + Tau2 limits table
     set.seed(1)
-    number.seq <- c(seq(0.1, 10, 0.1), seq(11.0, max_preds, 1))
+    number.seq <- c(seq(0.1, 10, 0.1), seq(11.0, max_preds, length.out = 1000))
     dfCI <- data.frame(
       number.seq,
       ll95 = multiplier * ((qchisq(0.975, 2 * number.seq, lower.tail = FALSE) / 2) / number.seq),
@@ -56,7 +56,7 @@ build_limits_lookup<-function(min_preds, max_preds, min_ratio, max_ratio, Poisso
     )
   } else if (method == "CQC") {
     set.seed(1)
-    number.seq <- seq(1, ceiling(as.numeric(max_preds)), 1)
+    number.seq <- seq(1, ceiling(as.numeric(max_preds)), length.out = 1000)
     dfCI <- data.frame(
       number.seq,
       ll95 = multiplier * ((qchisq(0.975, 2 * number.seq, lower.tail = FALSE) / 2) / number.seq),

--- a/tests/testthat/test-build_limits_lookup.R
+++ b/tests/testthat/test-build_limits_lookup.R
@@ -5,7 +5,7 @@ test_that("`build limits funcion` works with input and returns expected data.fra
   
   expect_s3_class(z, "data.frame")
   expect_length(z, 9)
-  expect_length(z$number.seq, 340)
+  expect_length(z$number.seq, 1100)
   #expect_equal(round(b$rr,6), c(1.069652, 1.071795, 1.022727))
   
 })


### PR DESCRIPTION
With larger datasets (e.g. denominator in the 100's of thousands), creating the CI matrix takes a long time. 
This small change should improve speed for such datasets. Currently set to length.out = 1000, which should be sufficient for most uses... (could even make it an option...)

