### PR TITLE
Outlier marking fixed

### DIFF
--- a/R/draw_plot.R
+++ b/R/draw_plot.R
@@ -35,7 +35,7 @@ draw_plot<-function(mod_plot_agg, limits, x_label, y_label, title, label, multip
   # Bind variable for NSE
   numerator <- denominator <- number.seq <- ll95 <- ul95 <- ll998 <- ul998 <- odll95 <- odul95 <-
     odll998 <- odul998 <- rr <- UCL95 <- group <- LCL95 <- OD95UCL <- OD95LCL <-UCL99 <-LCL99 <-
-    OD99UCL <- OD99LCL <- outlier <- NULL
+    OD99UCL <- OD99LCL <- outlier <- highlight <- NULL
   
   
   

--- a/R/draw_plot.R
+++ b/R/draw_plot.R
@@ -8,7 +8,6 @@
 #' @param title Plot title
 #' @param label Whether to label outliers, highlighted groups, both or none. Default is "outlier", by accepted values are: "outlier", "highlight", "both" or "NA".
 #' @param multiplier Scale relative risk and funnel by this factor. Default to 1, but 100 is used for HSMR
-#' @param highlight Single or vector of points to highlight, with a different colour and point style. Should correspond to values specified to `group`.
 #' @param Poisson_limits Draw exact limits based only on data points with no iterpolation. (default=FALSE)
 #' @param OD_adjust Draw overdispersed limits using Spiegelhalter's (2012) tau2 (default=TRUE)
 #' @param target the calculated target value for the data type
@@ -30,7 +29,7 @@
 
 
 draw_plot<-function(mod_plot_agg, limits, x_label, y_label, title, label, multiplier,
-                    highlight, Poisson_limits, OD_adjust, target, min_y, max_y, min_x, max_x
+                     Poisson_limits, OD_adjust, target, min_y, max_y, min_x, max_x
                     , data_type, sr_method, theme, plot_cols){
   
   # Bind variable for NSE
@@ -38,8 +37,6 @@ draw_plot<-function(mod_plot_agg, limits, x_label, y_label, title, label, multip
     odll998 <- odul998 <- rr <- UCL95 <- group <- LCL95 <- OD95UCL <- OD95LCL <-UCL99 <-LCL99 <-
     OD99UCL <- OD99LCL <- outlier <- NULL
   
-  # Add a colouring variable 
-  mod_plot_agg$highlight <- as.character(as.numeric(mod_plot_agg$group %in% highlight))
   
   
   # base funnel plot

--- a/R/draw_plot.R
+++ b/R/draw_plot.R
@@ -6,9 +6,9 @@
 #' @param x_label Title for the funnel plot x-axis.  Usually expected deaths, readmissions, incidents etc.
 #' @param y_label Title for the funnel plot y-axis.  Usually a standardised ratio.
 #' @param title Plot title
-#' @param label_outliers Add group labels to outliers on plot. Accepted values are\: 95 or 99 corresponding to 95\% or 99.8\% quantiles of the distribution. Default=99
+#' @param label Whether to label outliers, highlighted groups, both or none. Default is "outlier", by accepted values are: "outlier", "highlight", "both" or "NA".
 #' @param multiplier Scale relative risk and funnel by this factor. Default to 1, but 100 is used for HSMR
-#' @param higlight Single or vector of points to highlight, with a different colour and point style. Should correspond to values specified to `group`.
+#' @param highlight Single or vector of points to highlight, with a different colour and point style. Should correspond to values specified to `group`.
 #' @param Poisson_limits Draw exact limits based only on data points with no iterpolation. (default=FALSE)
 #' @param OD_adjust Draw overdispersed limits using Spiegelhalter's (2012) tau2 (default=TRUE)
 #' @param target the calculated target value for the data type
@@ -29,7 +29,7 @@
 #' @import ggplot2
 
 
-draw_plot<-function(mod_plot_agg, limits, x_label, y_label, title, label_outliers, multiplier,
+draw_plot<-function(mod_plot_agg, limits, x_label, y_label, title, label, multiplier,
                     highlight, Poisson_limits, OD_adjust, target, min_y, max_y, min_x, max_x
                     , data_type, sr_method, theme, plot_cols){
   
@@ -48,7 +48,7 @@ draw_plot<-function(mod_plot_agg, limits, x_label, y_label, title, label_outlier
     geom_hline(aes(yintercept = target * multiplier), linetype = 2) +
     scale_shape_manual(values = c("0"=21, "1"=23, 1))+
     scale_fill_manual(values = c("0"="dodgerblue","1"="yellow", 1))+
-    scale_size_manual(values = c("0"=2, "1"=3, 2))+
+    scale_size_manual(values = c("0"=2, "1"=3, 2), )+
     xlab(x_label) +
     ylab(y_label) +
     ggtitle(title) +
@@ -109,15 +109,32 @@ draw_plot<-function(mod_plot_agg, limits, x_label, y_label, title, label_outlier
   
   
 
- # Label outliers
-  
-  if(label_outliers==TRUE){
-  
-    funnel_p <- funnel_p +
-      geom_label_repel(aes(label = ifelse(outlier == 1,
-                                          as.character(group), ""))
-                       , size = 2.7, direction = "y",
-                       force = 2, min.segment.length = 0)
+ # Label points
+  if(!is.na(label)){
+    if(label=="outlier"){
+    
+      funnel_p <- funnel_p +
+        geom_label_repel(aes(label = ifelse(outlier == 1,
+                                            as.character(group), ""))
+                         , size = 2.7, direction = "both", 
+                         force = 2, min.segment.length = 0)
+    } 
+    
+    if(label=="highlight"){
+      funnel_p <- funnel_p +
+        geom_label_repel(aes(label = ifelse(highlight == 1,
+                                            as.character(group), ""))
+                         , size = 2.7, direction = "both", 
+                         force = 2, min.segment.length = 0)
+    } 
+    
+    if(label=="both"){
+      funnel_p <- funnel_p +
+        geom_label_repel(aes(label = ifelse((highlight == 1 | outlier == 1) ,
+                                            as.character(group), ""))
+                         , size = 2.7, direction = "both", 
+                         force = 2, min.segment.length = 0)
+    }
   }
      
   

--- a/R/funnel_plot.R
+++ b/R/funnel_plot.R
@@ -271,13 +271,15 @@ funnel_plot <- function(numerator, denominator, group, data_type = "SR", limit =
                               data_type=data_type, sr_method=sr_method, target=target, 
                               multiplier=multiplier)
   
+  # Add a colouring variable 
+  mod_plot_agg$highlight <- as.character(as.numeric(mod_plot_agg$group %in% highlight))
   
   # Add outliers flag
   mod_plot_agg <- outliers_func(mod_plot_agg, OD_adjust, Poisson_limits, limit, multiplier)
   
   # Assemble plot
   fun_plot<-draw_plot(mod_plot_agg, limits=plot_limits, x_label, y_label, title, label,
-                      multiplier=multiplier, highlight=highlight, 
+                      multiplier=multiplier,  
                       Poisson_limits=Poisson_limits, OD_adjust=OD_adjust,
                       target=target, min_y, max_y, min_x, max_x, data_type=data_type,
                       sr_method = sr_method, theme = theme, plot_cols=plot_cols)

--- a/R/od_adjustment.R
+++ b/R/od_adjustment.R
@@ -164,14 +164,17 @@ phi_func <- function(n, zscores){
 #'
 #'
 tau_func <- function(n,  phi, S){
-
-  if((n*phi) < (n - 1)){
+  
+  if(length(S) == 0){
     Tau2 <- 0
   } else {
-
-    Tau2 <- max(0, ((sum(n) * sum(phi)) - (sum(n) - 1)) /
-            (sum(1/(S^2)) - (sum((1/(S^2))^2) / sum(1/(S^2)))))
-
+      if((n*phi) < (n - 1)){
+      Tau2 <- 0
+    } else {
+  
+      Tau2 <- max(0, ((sum(n) * sum(phi)) - (sum(n) - 1)) /
+              (sum(1/(S^2)) - (sum((1/(S^2))^2) / sum(1/(S^2)))))
+    }
   }
 
   return(Tau2)

--- a/R/outliers_func.R
+++ b/R/outliers_func.R
@@ -4,33 +4,39 @@
 #' @param OD_adjust Logical for drawing OD limits, takes precedence over Poisson for outliers
 #' @param Poisson_limits Logical for drawing Poisson limits
 #' @param limit which limit to use.  Currently 95 or 99.
+#' @param multiplier the amount to scale the RR / limits by. Default is 1 \(no scaling\).
 #' 
 #' @keywords internal
-outliers_func <- function(mod_plot_agg, OD_adjust, Poisson_limits, limit){
+outliers_func <- function(mod_plot_agg, OD_adjust, Poisson_limits, limit, multiplier){
 
   if (limit == 95) {
     if (OD_adjust==FALSE){
-      mod_plot_agg$outlier <- ifelse(mod_plot_agg$rr <= mod_plot_agg$UCL95 &
-                                 mod_plot_agg$rr >= mod_plot_agg$LCL95,
-                                 0,
-                                 1)
+      #cat('1')
+       mod_plot_agg$outlier <- ifelse((multiplier*mod_plot_agg$rr) <= mod_plot_agg$UCL95 &
+                                        (multiplier*mod_plot_agg$rr) >= mod_plot_agg$LCL95,
+                                  0,
+                                  1)
     } else {
-      mod_plot_agg$outlier <- ifelse(mod_plot_agg$rr <= mod_plot_agg$OD95UCL &
-                                       mod_plot_agg$rr >= mod_plot_agg$OD95LCL,
+      #cat('2')
+      mod_plot_agg$outlier <- ifelse((multiplier*mod_plot_agg$rr) <= mod_plot_agg$OD95UCL &
+                                       (multiplier*mod_plot_agg$rr) >= mod_plot_agg$OD95LCL,
                                      0,
                                      1)
     }
   } else {
   
     if (limit == 99) {
-      if (OD_adjust==FALSE){
-        mod_plot_agg$outlier <- ifelse(mod_plot_agg$rr <= mod_plot_agg$UCL99 &
-                                         mod_plot_agg$rr >= mod_plot_agg$LCL99,
+      
+       if (OD_adjust==FALSE){
+      #   cat('3')
+        mod_plot_agg$outlier <- ifelse((multiplier*mod_plot_agg$rr) <= mod_plot_agg$UCL99 &
+                                         (multiplier*mod_plot_agg$rr) >= mod_plot_agg$LCL99,
                                        0,
                                        1)
       } else {
-        mod_plot_agg$outlier <- ifelse(mod_plot_agg$rr <= mod_plot_agg$OD99UCL &
-                                         mod_plot_agg$rr >= mod_plot_agg$OD99LCL,
+        # cat('4')
+        mod_plot_agg$outlier <- ifelse((multiplier*mod_plot_agg$rr) <= mod_plot_agg$OD99UCL &
+                                         (multiplier*mod_plot_agg$rr) >= mod_plot_agg$OD99LCL,
                                        0,
                                        1)
       }

--- a/dev/tests.R
+++ b/dev/tests.R
@@ -22,7 +22,7 @@ plot_cols = c("#FF7F0EFF", "#1F77B4FF", "#9467BDFF","#2CA02CFF")
 highlight = c("030001")
 
 # lets use the \'medpar\' dataset from the \'COUNT\' package. Little reformatting needed
-library(COUNT)
+#library(COUNT)
 data(medpar)
 medpar$provnum<-factor(medpar$provnum)
 medpar$los<-as.numeric(medpar$los)
@@ -35,8 +35,8 @@ medpar$prds<- predict(mod, type="response")
 
 # Draw plot, returning just the plot object
 fp2<-funnel_plot(denominator=medpar$prds,numerator=medpar$los, multiplier = 100,
-                 group = medpar$provnum, limit=99 ,label_outliers = TRUE, sr_method = "CQC",
-                 Poisson_limits = TRUE)
+                 group = medpar$provnum, limit=99 ,label = "outlier", sr_method = "CQC",
+                 Poisson_limits = TRUE, OD_adjust=FALSE, highlight = "030002")
 
 fp2
 class(fp2)
@@ -47,7 +47,7 @@ summary(fp2)
 phi(fp2)
 tau2(fp2)
 outliers(fp2)
-source_data(fp2)[53,]
+source_data(fp2)
 
 
 

--- a/man/draw_plot.Rd
+++ b/man/draw_plot.Rd
@@ -10,7 +10,7 @@ draw_plot(
   x_label,
   y_label,
   title,
-  label_outliers,
+  label,
   multiplier,
   highlight,
   Poisson_limits,
@@ -37,9 +37,11 @@ draw_plot(
 
 \item{title}{Plot title}
 
-\item{label_outliers}{Add group labels to outliers on plot. Accepted values are\: 95 or 99 corresponding to 95\% or 99.8\% quantiles of the distribution. Default=99}
+\item{label}{Whether to label outliers, highlighted groups, both or none. Default is "outlier", by accepted values are: "outlier", "highlight", "both" or "NA".}
 
 \item{multiplier}{Scale relative risk and funnel by this factor. Default to 1, but 100 is used for HSMR}
+
+\item{highlight}{Single or vector of points to highlight, with a different colour and point style. Should correspond to values specified to `group`.}
 
 \item{Poisson_limits}{Draw exact limits based only on data points with no iterpolation. (default=FALSE)}
 
@@ -60,8 +62,6 @@ draw_plot(
 \item{sr_method}{CQC or SHMI methods for standardised ratios}
 
 \item{theme}{a ggplot theme function.}
-
-\item{higlight}{Single or vector of points to highlight, with a different colour and point style. Should correspond to values specified to `group`.}
 }
 \value{
 A list containing [1] the funnel plot as a ggplot2 object., [2]the limits table.

--- a/man/draw_plot.Rd
+++ b/man/draw_plot.Rd
@@ -12,7 +12,6 @@ draw_plot(
   title,
   label,
   multiplier,
-  highlight,
   Poisson_limits,
   OD_adjust,
   target,
@@ -40,8 +39,6 @@ draw_plot(
 \item{label}{Whether to label outliers, highlighted groups, both or none. Default is "outlier", by accepted values are: "outlier", "highlight", "both" or "NA".}
 
 \item{multiplier}{Scale relative risk and funnel by this factor. Default to 1, but 100 is used for HSMR}
-
-\item{highlight}{Single or vector of points to highlight, with a different colour and point style. Should correspond to values specified to `group`.}
 
 \item{Poisson_limits}{Draw exact limits based only on data points with no iterpolation. (default=FALSE)}
 

--- a/man/funnel_plot.Rd
+++ b/man/funnel_plot.Rd
@@ -11,7 +11,7 @@ funnel_plot(
   group,
   data_type = "SR",
   limit = 99,
-  label_outliers = TRUE,
+  label = "outlier",
   highlight = FALSE,
   Poisson_limits = FALSE,
   OD_adjust = TRUE,
@@ -38,7 +38,7 @@ funnel_plot(
 
 \item{limit}{Plot limits, accepted values are: 95 or 99, corresponding to 95\% or 99.8\% quantiles of the distribution. Default=99,and applies to OD limits if both OD and Poisson are used.}
 
-\item{label_outliers}{Logical (TRUE or FALSE) for adding outlier labels to the plot.}
+\item{label}{Whether to label outliers, highlighted groups, both or none. Default is "outlier", by accepted values are: "outlier", "highlight", "both" or "NA".}
 
 \item{highlight}{Single or vector of points to highlight, with a different colour and point style. Should correspond to values specified to `group`.}
 
@@ -92,7 +92,7 @@ and constructing an additive random effects models, originally used for meta-ana
 }
 \details{
 Outliers are marked based on the grouping, and the limits chosen, corresponding to either 95\% or 99.8\% quantiles of the normal distribution.\cr
-   Labels can be turned on or of using the `label_outliers` argument.\cr
+   Labels can attached using the `label` argument.\cr
    Overdispersion can be factored in based on the methods in Spiegelhalter et al. (2012), set `OD_adjust` to FALSE to suppress this. \cr
    To use Poisson limits set `Poisson_limits=TRUE`. \cr
    The plot colours deliberately avoid red-amber-green colouring, but you could extract this from the ggplot object and change manually if you like.

--- a/man/outliers_func.Rd
+++ b/man/outliers_func.Rd
@@ -4,7 +4,7 @@
 \alias{outliers_func}
 \title{Label outliers}
 \usage{
-outliers_func(mod_plot_agg, OD_adjust, Poisson_limits, limit)
+outliers_func(mod_plot_agg, OD_adjust, Poisson_limits, limit, multiplier)
 }
 \arguments{
 \item{mod_plot_agg}{Aggregated data set for plotting}
@@ -14,6 +14,8 @@ outliers_func(mod_plot_agg, OD_adjust, Poisson_limits, limit)
 \item{Poisson_limits}{Logical for drawing Poisson limits}
 
 \item{limit}{which limit to use.  Currently 95 or 99.}
+
+\item{multiplier}{the amount to scale the RR / limits by. Default is 1 \(no scaling\).}
 }
 \description{
 Label outliers

--- a/tests/testthat/test-funnel_plot.R
+++ b/tests/testthat/test-funnel_plot.R
@@ -7,43 +7,44 @@ test_that("`funnel_plot()` works with input and returns expected list", {
   expect_s3_class(a[[2]], "data.frame")
   expect_s3_class(a[[3]], "data.frame")
   expect_length(a[[3]]$group,6)
-  expect_length(a[[3]],21)
+  expect_length(a[[3]],22)
 
   b<-funnel_plot(numerator=c(100, 150,180,80,120, 225), denominator=c(108, 112, 165,95,100, 220),
                  group=factor(c("a","b","c", "d","e","f")), OD_adjust = FALSE,
                  title="My test Funnel Plot", multiplier = 100, x_label = "Expected Values",
-                 y_label = "Standardised Ratio Test", label_outliers = TRUE, limit=95)
+                 y_label = "Standardised Ratio Test", label = "outlier", limit=95)
   expect_type(b, "list")
   expect_type(b[[1]], "list")
   expect_s3_class(b[[2]], "data.frame")
   expect_s3_class(b[[3]], "data.frame")
   expect_length(b[[3]]$group,6)
-  expect_length(b[[3]],21)
+  expect_length(b[[3]],22)
   expect_gt(b[[3]]$LCL95[5], a[[3]]$OD95LCL[5])
 
   c<-funnel_plot(numerator=c(100, 150,180,80,120, 225), denominator=c(108, 112, 165,95,100, 220),
                  group=factor(c("a","b","c", "d","e","f")), OD_adjust = TRUE, sr_method="CQC", trim_by = 0.05,
                  title="My test Funnel Plot", multiplier = 100, x_label = "Expected Values",
-                 y_label = "Standardised Ratio Test", label_outliers = TRUE, limit=95)
+                 y_label = "Standardised Ratio Test", label = "highlight", limit=95, highlight="a")
   expect_type(c, "list")
   expect_type(c[[1]], "list")
   expect_s3_class(c[[2]], "data.frame")
   expect_s3_class(c[[3]], "data.frame")
   expect_length(c[[3]]$group,6)
-  expect_length(c[[3]],19)
+  expect_length(c[[3]],20)
   expect_lt(b[[3]]$OD95LCL[5], c[[3]]$OD95LCL[5])
+  expect_equal(source_data(c)$highlight[1],"1")
 
   d<-funnel_plot(numerator=c(100, 150,180,80,120, 225), denominator=c(108, 112, 165,95,100, 220),
                  group=factor(c("a","b","c", "d","e","f")), OD_adjust = FALSE, sr_method="CQC", trim_by = 0.05,
                  title="My test Funnel Plot", multiplier = 100, x_label = "Expected Values",
-                 y_label = "Standardised Ratio Test", label_outliers = TRUE, limit=95, xrange=c(5,250)
-                 , yrange=c(0, 200))
+                 y_label = "Standardised Ratio Test", label = "both", limit=95, xrange=c(5,250)
+                 , yrange=c(0, 200), highlight="a")
   expect_type(d, "list")
   expect_type(d[[1]], "list")
   expect_s3_class(d[[2]], "data.frame")
   expect_s3_class(d[[3]], "data.frame")
   expect_length(d[[3]]$group,6)
-  expect_length(d[[3]],19)
+  expect_length(d[[3]],20)
 
 
 })

--- a/vignettes/changing_funnel_plot_options.Rmd
+++ b/vignettes/changing_funnel_plot_options.Rmd
@@ -149,7 +149,7 @@ Since `funnelplotr` uses `ggplot2`, you could always extract the plot and alter 
 # Original funnel plot object
 fp <-
 funnel_plot(denominator=medpar$prds,numerator=medpar$los
-            , group = medpar$provnum, limit=99 ,label = "outlier"
+            , group = medpar$provnum, limit=99, label = "outlier"
             , Poisson_limits = TRUE)
 
 # Extract just the plot

--- a/vignettes/changing_funnel_plot_options.Rmd
+++ b/vignettes/changing_funnel_plot_options.Rmd
@@ -43,9 +43,22 @@ medpar$prds<- predict(mod, type="response")
 
 # Draw plot, returning just the plot object
 funnel_plot(denominator=medpar$prds,numerator=medpar$los
-            , group = medpar$provnum, limit=99 ,label_outliers = TRUE
+            , group = medpar$provnum, limit=99 ,label = "outlier"
             , Poisson_limits = TRUE)
 
+
+```
+
+
+## Highlighting a data point
+
+You can pick out data point(s) using the `highlight` option.  Here we we use the example above to highlight the hospital labels '030002' in the data set.
+
+```{r highlight}
+# Draw plot, returning just the plot object
+funnel_plot(denominator=medpar$prds,numerator=medpar$los
+            , group = medpar$provnum, limit=99 ,label = "outlier"
+            , Poisson_limits = TRUE, highlight="030002")
 ```
 
 
@@ -56,7 +69,7 @@ You can alter themes in the `funnelplotr` packages by using the theme argument. 
 ```{r plottheme1}
 
 funnel_plot(denominator=medpar$prds,numerator=medpar$los
-            , group = medpar$provnum, limit=99 ,label_outliers = TRUE
+            , group = medpar$provnum, limit=99 ,label = "outlier"
             , Poisson_limits = TRUE, theme = funnel_grey() )
 
 ```
@@ -75,7 +88,7 @@ new_funnel_theme <-
   
 
 funnel_plot(denominator=medpar$prds,numerator=medpar$los 
-            , group = medpar$provnum, limit=99 ,label_outliers = TRUE
+            , group = medpar$provnum, limit=99 ,label = "outlier"
             , Poisson_limits = TRUE, theme = new_funnel_theme)
 
 ```
@@ -89,7 +102,7 @@ Here are four other colours instead:
 
 ```{r colours}
 funnel_plot(denominator=medpar$prds,numerator=medpar$los 
-            , group = medpar$provnum, limit=99 ,label_outliers = TRUE
+            , group = medpar$provnum, limit=99 ,label = "outlier"
             , Poisson_limits = TRUE, plot_cols= c("#8c8c8c", "#00b159", "#00aedb", "#d11141"))
 ```
 
@@ -100,7 +113,7 @@ funnel_plot(denominator=medpar$prds,numerator=medpar$los
 ```{r funnelscales}
 ## Changing labels
 funnel_plot(denominator=medpar$prds,numerator=medpar$los 
-            , group = medpar$provnum, limit=99 ,label_outliers = TRUE
+            , group = medpar$provnum, limit=99 ,label = "outlier"
             , Poisson_limits = TRUE, xrange=c(0, 400), yrange=c(0,2))
 
 ```
@@ -111,11 +124,21 @@ funnel_plot(denominator=medpar$prds,numerator=medpar$los
 
 You can change the plot labels and axis labels easily using the options: `title`, `x_label` and `y_label`.
 
-```{r funnellabels}
+```{r funnellabels1}
 funnel_plot(denominator=medpar$prds,numerator=medpar$los 
-            , group = medpar$provnum, limit=99 ,label_outliers = TRUE
+            , group = medpar$provnum, limit=99 ,label = "outlier"
             , Poisson_limits = TRUE, title = "Vignette funnel plot"
             , x_label = "x-axis", y_label = "y-axis")
+```
+
+There are different labelling options for the data points too, using the `label` option.  The default is to label outliers, but you can turn labels off, label the highlighted points, or both the highlighted points and the outliers ('both')
+
+```{r funnellabels2}
+funnel_plot(denominator=medpar$prds,numerator=medpar$los 
+            , group = medpar$provnum, limit=99 
+            , Poisson_limits = TRUE, title = "Vignette funnel plot"
+            , x_label = "x-axis", y_label = "y-axis"
+            , highlight= "030002", label = "highlight")
 ```
 
 ## Cutting out the ggplot object
@@ -126,7 +149,7 @@ Since `funnelplotr` uses `ggplot2`, you could always extract the plot and alter 
 # Original funnel plot object
 fp <-
 funnel_plot(denominator=medpar$prds,numerator=medpar$los
-            , group = medpar$provnum, limit=99 ,label_outliers = TRUE
+            , group = medpar$provnum, limit=99 ,label = "outlier"
             , Poisson_limits = TRUE)
 
 # Extract just the plot

--- a/vignettes/funnel_plots.Rmd
+++ b/vignettes/funnel_plots.Rmd
@@ -140,13 +140,13 @@ medpar$prds<- predict(mod, type="response")
 
 ### Build plot
 
-Now we can build a funnel plot object with standard Poisson limits, and outliers labelled.  The function returns a list of the plotted data, the plotted control limit range, and the `ggplot` object, hence `object[3]` to call it.
+Now we can build a funnel plot object with standard Poisson limits, and outliers labelled.  The function returns an S3 object, with various methods including `print()`, `outlier()`, `limits()`, `source_data()` etc.  See the help file: `?funnel_plot` for more details.  
 
 ```{r, funnel1, message=FALSE, fig.align='center', fig.retina=5, collapse=TRUE}
 
 funnel_plot(numerator=medpar$los, denominator=medpar$prds, group = medpar$provnum, 
             title = 'Length of Stay Funnel plot for `medpar` data', Poisson_limits = TRUE,
-            OD_adjust = FALSE,label_outliers = TRUE, limit=99)
+            OD_adjust = FALSE,label = "outlier", limit=99)
 ```
 
 <br>
@@ -172,7 +172,7 @@ This is a huge topic, but applying overdispersed limits using either SHMI or Spi
 ```{r, funnel2, message=FALSE, fig.align='center', fig.retina=5, collapse=TRUE}
 funnel_plot(numerator=medpar$los, denominator=medpar$prds, group = medpar$provnum, 
             title = 'Length of Stay Funnel plot for `medpar` data', Poisson_limits = FALSE,
-            OD_adjust = TRUE, data_type="SR", sr_method = "SHMI",label_outliers = TRUE, limit=99
+            OD_adjust = TRUE, data_type="SR", sr_method = "SHMI",label = "outlier", limit=99
             )
 ```
 


### PR DESCRIPTION
Bug was not carrying scaling 'multiplier' argument into the outlier assessment, so it didn't work when different to 1.  Added a relabelling systems to facilitate better use, updated tests and vignettes accordingly.  Closes #24 