### PR TITLE
Compatibility ggplot2 4.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Encoding: UTF-8
 Imports: 
     dplyr,
     ggrepel,
-    ggplot2,
+    ggplot2 (>= 3.5.2),
     scales,
     rlang
 RoxygenNote: 7.3.1

--- a/R/classes_methods.R
+++ b/R/classes_methods.R
@@ -19,7 +19,7 @@ new_funnel_plot <- function(x = list()) {
 
 validate_funnel_plot <- function(funnelplot){
 
-  if (!is.list(funnelplot[[1]])){
+  if (!is_ggplot(funnelplot[[1]])){
     stop(
       "Invalid ggplot object"
     )

--- a/tests/testthat/test-classes_methods.R
+++ b/tests/testthat/test-classes_methods.R
@@ -9,7 +9,7 @@ test_that("`test the classes return stuff", {
   expect_s3_class(a, "funnelplot") 
   expect_equal(round(phi.funnelplot(a),6), 2.948033)
   expect_type(a, "list")
-  expect_type(a[[1]], "list")
+  expect_true(is_ggplot(a[[1]]))
   expect_s3_class(a[[2]], "data.frame")
   expect_s3_class(a[[3]], "data.frame")
   expect_length(a[[3]]$group,6)

--- a/tests/testthat/test-funnel_plot.R
+++ b/tests/testthat/test-funnel_plot.R
@@ -6,7 +6,7 @@ test_that("`funnel_plot()` works with input and returns expected list", {
   
   a<-funnel_plot(dt, num, denom, group)
   expect_type(a, "list")
-  expect_type(a[[1]], "list")
+  expect_true(is_ggplot(a[[1]]))
   expect_s3_class(a[[2]], "data.frame")
   expect_s3_class(a[[3]], "data.frame")
   expect_length(a[[3]]$group,6)
@@ -16,7 +16,7 @@ test_that("`funnel_plot()` works with input and returns expected list", {
                  title="My test Funnel Plot", multiplier = 100, x_label = "Expected Values",
                  y_label = "Standardised Ratio Test", label = "outlier", limit=95)
   expect_type(b, "list")
-  expect_type(b[[1]], "list")
+  expect_true(is_ggplot(b[[1]]))
   expect_s3_class(b[[2]], "data.frame")
   expect_s3_class(b[[3]], "data.frame")
   expect_length(b[[3]]$group,6)
@@ -27,7 +27,7 @@ test_that("`funnel_plot()` works with input and returns expected list", {
                  title="My test Funnel Plot", multiplier = 100, x_label = "Expected Values",
                  y_label = "Standardised Ratio Test", label = "highlight", limit=95, highlight="a")
   expect_type(c, "list")
-  expect_type(c[[1]], "list")
+  expect_true(is_ggplot(c[[1]]))
   expect_s3_class(c[[2]], "data.frame")
   expect_s3_class(c[[3]], "data.frame")
   expect_length(c[[3]]$group,6)
@@ -40,7 +40,7 @@ test_that("`funnel_plot()` works with input and returns expected list", {
                  y_label = "Standardised Ratio Test", label = "both", limit=95, x_range=c(5,250)
                  , y_range=c(0, 200), highlight="a")
   expect_type(d, "list")
-  expect_type(d[[1]], "list")
+  expect_true(is_ggplot(d[[1]]))
   expect_s3_class(d[[2]], "data.frame")
   expect_s3_class(d[[3]], "data.frame")
   expect_length(d[[3]]$group,6)


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The issue is described in https://github.com/tidyverse/ggplot2/issues/6498, where you're welcome to raise discussion.
The issue relates both to unit tests and packaged code, so we propose the changes in this PR.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun